### PR TITLE
chore: update KDE runtime to v6.10

### DIFF
--- a/org.bunkus.mkvtoolnix-gui.yaml
+++ b/org.bunkus.mkvtoolnix-gui.yaml
@@ -48,6 +48,16 @@ modules:
         url: https://github.com/commonmark/cmark/archive/refs/tags/0.31.1.tar.gz
         sha256: 3da93db5469c30588cfeb283d9d62edfc6ded9eb0edc10a4f5bbfb7d722ea802
 
+  - name: cmark-docs
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/share/doc/cmark
+      - install -m0644 -t/app/share/doc/cmark COPYING README.md
+    sources:
+      - type: archive
+        url: https://mkvtoolnix.download/sources/mkvtoolnix-96.0.tar.xz
+        sha256: 509a1e3aca1f63fe5cc96b4c7272ba533dbcbb69c61d1c5114dccf610fd405cb
+
   - name: libdvdcss
     sources:
       - type: archive
@@ -59,6 +69,7 @@ modules:
       - type: archive
         url: https://download.videolan.org/pub/videolan/libdvdread/6.1.3/libdvdread-6.1.3.tar.bz2
         sha256: ce35454997a208cbe50e91232f0e73fb1ac3471965813a13b8730a8f18a15369
+
   - name: mkvtoolnix
     buildsystem: simple
     build-commands:
@@ -83,6 +94,18 @@ modules:
       #   url: https://gitlab.com/mbunkus/mkvtoolnix.git
       #   branch: main
       #   commit: 29f4f99e1b046c53812b90309badef4915db8510
+    modules:
+      - name: ruby
+        sources:
+          - type: archive
+            url: https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.7.tar.gz
+            sha256: 23815a6d095696f7919090fdc3e2f9459b2c83d57224b2e446ce1f5f7333ef36
+            x-checker-data:
+              type: anitya
+              project-id: 4223
+              url-template: https://cache.ruby-lang.org/pub/ruby/{major}.{minor}/ruby-${version}.tar.gz
+        cleanup:
+          - '*'
 
   - name: mkvtoolnix-wrapper
     buildsystem: simple
@@ -91,14 +114,3 @@ modules:
     sources:
       - type: file
         path: entrypoint.sh
-
-  - name: cmark-docs
-    buildsystem: simple
-    build-commands:
-      - mkdir -p /app/share/doc/cmark
-      - install -m0644 -t/app/share/doc/cmark COPYING README.md
-    sources:
-      - type: archive
-        url: https://mkvtoolnix.download/sources/mkvtoolnix-96.0.tar.xz
-        sha256: 509a1e3aca1f63fe5cc96b4c7272ba533dbcbb69c61d1c5114dccf610fd405cb
-

--- a/org.bunkus.mkvtoolnix-gui.yaml
+++ b/org.bunkus.mkvtoolnix-gui.yaml
@@ -1,7 +1,7 @@
 app-id: org.bunkus.mkvtoolnix-gui
 default-branch: stable
 runtime: org.kde.Platform
-runtime-version: '6.8'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 command: mkvtoolnix
 rename-icon: mkvtoolnix-gui

--- a/org.bunkus.mkvtoolnix-gui.yaml
+++ b/org.bunkus.mkvtoolnix-gui.yaml
@@ -48,16 +48,6 @@ modules:
         url: https://github.com/commonmark/cmark/archive/refs/tags/0.31.1.tar.gz
         sha256: 3da93db5469c30588cfeb283d9d62edfc6ded9eb0edc10a4f5bbfb7d722ea802
 
-  - name: cmark-docs
-    buildsystem: simple
-    build-commands:
-      - mkdir -p /app/share/doc/cmark
-      - install -m0644 -t/app/share/doc/cmark COPYING README.md
-    sources:
-      - type: archive
-        url: https://mkvtoolnix.download/sources/mkvtoolnix-96.0.tar.xz
-        sha256: 509a1e3aca1f63fe5cc96b4c7272ba533dbcbb69c61d1c5114dccf610fd405cb
-
   - name: libdvdcss
     sources:
       - type: archive
@@ -114,3 +104,13 @@ modules:
     sources:
       - type: file
         path: entrypoint.sh
+
+  - name: cmark-docs
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/share/doc/cmark
+      - install -m0644 -t/app/share/doc/cmark COPYING README.md
+    sources:
+      - type: archive
+        url: https://mkvtoolnix.download/sources/mkvtoolnix-96.0.tar.xz
+        sha256: 509a1e3aca1f63fe5cc96b4c7272ba533dbcbb69c61d1c5114dccf610fd405cb


### PR DESCRIPTION
I had to add Ruby as build dependency since it was [dropped](https://discourse.flathub.org/t/freedesktop-sdk-25-08-0-released/10399) from Freedesktop SDK 25.08.

~~Additionally, I've sorted the modules alphabetically (moved the `cmark-docs` module up).~~